### PR TITLE
[ci skip] removing user @goanpeca

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -54,7 +54,6 @@ about:
 
 extra:
   recipe-maintainers:
-    - goanpeca
     - jaimergp
     - tlambert03
     - psobolewskiPhD


### PR DESCRIPTION
Manually removing @goanpeca from the maintainers list because the conda-forge-admin bot has not processed the request.

Closes #12